### PR TITLE
feat: fix scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "contributors": [
     "S. Amir Mohammad Najafi <njfamirm@gamil.com> (njfamirm.ir"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { createLogger } from "@alwatr/logger";
 
 const clientId = process.env.OAUTH_GITHUB_CLIENT_ID
 const clientSecret = process.env.OAUTH_GITHUB_CLIENT_SECRET
+const scope = process.env.OAUTH_GITHUB_SCOPE
 
 if (clientId == undefined) {
   throw new Error('github client id required, OAUTH_GITHUB_CLIENT_ID="123_123_123" yarn start');
@@ -15,6 +16,7 @@ export const config = {
     id: clientId as string,
     secret: clientSecret as string,
   },
+  scope: scope || 'repo',
   auth: {
     tokenHost: 'https://github.com',
     tokenPath: '/login/oauth/access_token',

--- a/src/route/auth.ts
+++ b/src/route/auth.ts
@@ -26,7 +26,7 @@ nanoServer.route('GET', '/auth', (connection) => {
 
   const authorizationUri = client.authorizeURL({
     redirect_uri: `https://${host}/callback?provider=${provider}`,
-    scope: 'repo',
+    scope: config.scope,
     state: randomString(),
   });
 

--- a/src/route/auth.ts
+++ b/src/route/auth.ts
@@ -26,7 +26,7 @@ nanoServer.route('GET', '/auth', (connection) => {
 
   const authorizationUri = client.authorizeURL({
     redirect_uri: `https://${host}/callback?provider=${provider}`,
-    scope: 'repo,user',
+    scope: 'repo',
     state: randomString(),
   });
 


### PR DESCRIPTION
This PR removes OAuth scope `user` because it is unnecessary and asking the user for this scope is a security risk. The original Netlify implementation for Decap does not require this scope, the necessary read-only user profile information is available [without scope](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes).

In addition, it allows you to define a custom scope with the environment variable `OAUTH_GITHUB_SCOPE`, which is useful when you need only the scope `public_repo` instead of `repo` (which is in most cases and is up for consideration that `public_repo` should be default instead of `repo`).

I have tested and I also have this version deployed in production and Decap works for the users and also in open authoring mode.